### PR TITLE
Fix Readme capitalization in pyproject.toml

### DIFF
--- a/sbom-tools/pyproject.toml
+++ b/sbom-tools/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
   { name="Eclipse KUKSA project", email="sebastian.schildt@de.bosch.com" },
 ]
 description = "KUKSA SBOM utils"
-readme = "Readme.md"
+readme = "README.md"
 requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Did not catch it before because did not run on Linux and APFS doesn't care