### PR TITLE
Feature/ecc token support

### DIFF
--- a/jwt/createToken.py
+++ b/jwt/createToken.py
@@ -20,8 +20,26 @@ import argparse
 import sys
 from os import path
 
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey, SECP256R1
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
 import json
 import jwt
+
+
+def infer_algorithm(priv_key_pem: str) -> str:
+    key = load_pem_private_key(priv_key_pem.encode(), password=None)
+    if isinstance(key, RSAPrivateKey):
+        return "RS256"
+    if isinstance(key, EllipticCurvePrivateKey):
+        if isinstance(key.curve, SECP256R1):
+            return "ES256"
+        raise ValueError(f"Unsupported EC curve: {key.curve.name}")
+    if isinstance(key, Ed25519PrivateKey):
+        return "EdDSA"
+    raise ValueError(f"Unsupported key type: {type(key).__name__}")
 
 
 def error_exit(msg):
@@ -29,12 +47,12 @@ def error_exit(msg):
     sys.exit(1)
 
 
-def createJWTToken(input_filename, priv_key, output_filename=None):
+def createJWTToken(input_filename, priv_key, algorithm, output_filename=None):
     print("Reading JWT payload from {}".format(input_filename))
     with open(input_filename, "r") as file:
         payload = json.load(file)
 
-    encoded = jwt.encode(payload, priv_key, algorithm="RS256")
+    encoded = jwt.encode(payload, priv_key, algorithm=algorithm)
 
     if output_filename is None:
         output_filename = input_filename[:-5] if input_filename.endswith(".json") else input_filename
@@ -61,12 +79,15 @@ def main():
         Output filename can be specified for single input file only!
         """)
 
-    print("Reading private key from {}".format("jwt.key"))
+    print("Reading private key from {}".format(args.priv_key_filename))
     with open(args.priv_key_filename, "r") as file:
         priv_key = file.read()
 
+    algorithm = infer_algorithm(priv_key)
+    print("Detected key algorithm: {}".format(algorithm))
+
     for input_file in args.files:
-        createJWTToken(input_file, priv_key, args.output)
+        createJWTToken(input_file, priv_key, algorithm, args.output)
 
 
 if __name__ == "__main__":

--- a/jwt/recreateJWTkeyPair.sh
+++ b/jwt/recreateJWTkeyPair.sh
@@ -1,23 +1,76 @@
-#!/bin/sh
-
-# Copyright Robert Bosch GmbH, 2020. Part of the Eclipse Kuksa Project.
+#!/bin/bash
 #
-# All rights reserved. This configuration file is provided to you under the
-# terms and conditions of the Eclipse Distribution License v1.0 which
-# accompanies this distribution, and is available at
-# http://www.eclipse.org/org/documents/edl-v10.php
+# Copyright (c) 2020-2026 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
 
+ALGORITHM="ES256"
 
+usage() {
+    echo "Usage: $0 [--algorithm <ES256|EdDSA|RS256>]"
+    echo ""
+    echo "  --algorithm   Key type to generate (default: ES256)"
+    echo "                ES256  - ECDSA with P-256 curve"
+    echo "                EdDSA  - Edwards-curve DSA (Ed25519)"
+    echo "                RS256  - RSA 4096-bit"
+    exit 1
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --algorithm)
+            ALGORITHM="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+case "$ALGORITHM" in
+    ES256|EdDSA|RS256) ;;
+    *)
+        echo "Error: unsupported algorithm '$ALGORITHM'. Choose ES256, EdDSA, or RS256."
+        exit 1
+        ;;
+esac
 
 echo "Recreating KUKSA key pair used for JWT verification"
 echo "-------------------------------------------------------"
+echo "Algorithm: $ALGORITHM"
 
+case "$ALGORITHM" in
+    ES256)
+        printf "\nCreating private key (ECDSA P-256)\n"
+        openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out jwt.key
 
-printf "\nCreating private key\n"
-ssh-keygen -t rsa -b 4096 -m PEM -f jwt.key -q -N ""
+        printf "\nCreating public key\n"
+        openssl pkey -in jwt.key -pubout -out jwt.key.pub
+        ;;
+    EdDSA)
+        printf "\nCreating private key (Ed25519)\n"
+        openssl genpkey -algorithm Ed25519 -out jwt.key
 
-printf "\nCreating public key\n"
-openssl rsa -in jwt.key -pubout -outform PEM -out jwt.key.pub
+        printf "\nCreating public key\n"
+        openssl pkey -in jwt.key -pubout -out jwt.key.pub
+        ;;
+    RS256)
+        printf "\nCreating private key (RSA 4096)\n"
+        openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:4096 -out jwt.key
+
+        printf "\nCreating public key\n"
+        openssl pkey -in jwt.key -pubout -out jwt.key.pub
+        ;;
+esac
 
 printf '\nYou can use the PRIVATE key "jwt.key" to generate new tokens using https://jwt.io or the "createToken.py" script.\n'
 echo 'You need to give the PUBLIC key "jwt.key.pub" to the KUKSA Databroker, so it can verify correctly signed JWT tokens.'


### PR DESCRIPTION
Preparation for updated jwt signature algorithm support as in https://github.com/eclipse-kuksa/kuksa-databroker/pull/197

This is NOT changing the example tokens yet, so it should be safe to merge. Changes

 - recreateJWTkeyPair.sh can now also create a EdDSA or ES256 keypair. RSA256 (the only option before) is still supported (however I also create it with openssl now instead of ssh-keygen)
 - createToken.py (that actually uses the private key to sign the jwts) is updated to support the new keytypes as well. 
